### PR TITLE
Refactor: Extract dereferenced pointers to field symbols

### DIFF
--- a/src/z2ui5_cl_pop_search_help.clas.abap
+++ b/src/z2ui5_cl_pop_search_help.clas.abap
@@ -100,6 +100,8 @@ CLASS z2ui5_cl_pop_search_help IMPLEMENTATION.
                           editable = abap_true
           )->content( ns = 'form' ).
 
+    ASSIGN ms_data_row->* TO FIELD-SYMBOL(<data_row>).
+
     " Gehe über alle Comps
     LOOP AT mt_result_desc REFERENCE INTO DATA(dfies).
 
@@ -110,7 +112,7 @@ CLASS z2ui5_cl_pop_search_help IMPLEMENTATION.
         enabled = abap_false.
       ENDIF.
 
-      ASSIGN COMPONENT dfies->fieldname OF STRUCTURE ms_data_row->* TO FIELD-SYMBOL(<val>).
+      ASSIGN COMPONENT dfies->fieldname OF STRUCTURE <data_row> TO FIELD-SYMBOL(<val>).
 
       simple_form->label( text = z2ui5_cl_util=>rtti_get_data_element_text_l( dfies->rollname ) ).
 
@@ -275,9 +277,11 @@ CLASS z2ui5_cl_pop_search_help IMPLEMENTATION.
 
     CLEAR ms_shlp-selopt.
 
+    ASSIGN ms_data_row->* TO FIELD-SYMBOL(<data_row>).
+
     LOOP AT mt_result_desc INTO DATA(dfies).
 
-      ASSIGN COMPONENT dfies-fieldname OF STRUCTURE ms_data_row->* TO FIELD-SYMBOL(<value>).
+      ASSIGN COMPONENT dfies-fieldname OF STRUCTURE <data_row> TO FIELD-SYMBOL(<value>).
 
       IF sy-subrc <> 0.
         CONTINUE.
@@ -301,9 +305,11 @@ CLASS z2ui5_cl_pop_search_help IMPLEMENTATION.
 
     CLEAR ms_shlp-selopt.
 
+    ASSIGN mr_data->* TO FIELD-SYMBOL(<data>).
+
     LOOP AT mt_result_desc INTO DATA(dfies).
 
-      ASSIGN COMPONENT dfies-fieldname OF STRUCTURE mr_data->* TO FIELD-SYMBOL(<value>).
+      ASSIGN COMPONENT dfies-fieldname OF STRUCTURE <data> TO FIELD-SYMBOL(<value>).
 
       IF sy-subrc <> 0.
         CONTINUE.


### PR DESCRIPTION
## Summary
This change improves code readability and performance by extracting dereferenced pointers into field symbols before use, rather than repeatedly dereferencing them inline.

## Key Changes
- **Line 103**: Extract `ms_data_row->*` to field symbol `<data_row>` before the loop that processes result descriptions
- **Line 115**: Replace inline dereference `ms_data_row->*` with field symbol `<data_row>` in ASSIGN statement
- **Line 280**: Extract `ms_data_row->*` to field symbol `<data_row>` before processing field descriptions
- **Line 284**: Replace inline dereference `ms_data_row->*` with field symbol `<data_row>` in ASSIGN statement
- **Line 308**: Extract `mr_data->*` to field symbol `<data>` before processing field descriptions
- **Line 312**: Replace inline dereference `mr_data->*` with field symbol `<data>` in ASSIGN statement

## Implementation Details
The refactoring follows the DRY (Don't Repeat Yourself) principle by assigning dereferenced pointers to field symbols once at the beginning of each processing block, then reusing those field symbols throughout the loop. This approach:
- Reduces redundant pointer dereferences
- Improves code maintainability
- Makes the code more efficient by avoiding repeated dereference operations
- Maintains the same functional behavior while improving clarity

https://claude.ai/code/session_019heiFHwPZNtnSVHPUEgxiW