### PR TITLE
Clarify vendored utility class maintenance model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,14 +22,14 @@ Ready-to-use popup and dialog apps for [abap2UI5](https://github.com/abap2UI5/ab
 
 ## The Utility Copy Principle (`src/00/`)
 
-`z2ui5_cl_popup_context` is a **renamed copy** of `zabaputil_cl_util_context` from the [abap-util](https://github.com/abap-util/abap-util) **master repository**, **trimmed to the methods the popup apps actually use**. This repo has no install-time dependency on abap-util — abapGit has no dependency management, so utilities are vendored instead of referenced. The same pattern is used by the abap2UI5 core (`z2ui5_cl_a2ui5_context` in its `src/00/03/`).
+`z2ui5_cl_popup_context` is a **renamed copy** of `zabaputil_cl_util_context` from the [abap-util](https://github.com/abap-util/abap-util) **master catalog** (which contains all utility classes with all methods), **trimmed to the methods the popup apps actually use**. This repo has no install-time dependency on abap-util — abapGit has no dependency management, so utilities are vendored instead of referenced. The same pattern is used by the abap2UI5 core (`z2ui5_cl_a2ui5_context` in its `src/00/03/`).
 
-**Rules — these are hard constraints:**
+**How the copy is maintained:**
 
-1. **Never fix utility logic only in `z2ui5_cl_popup_context`.** The fix belongs in abap-util (where it is unit-tested), and is then applied identically to the copy here. A copy-only fix is lost for every other consumer and overwritten by the next sync.
-2. **The copy may differ from the abap-util master in exactly two ways:** the class name (`z2ui5_cl_popup_context`) and the set of methods (only what the popups use). Method implementations must stay textually identical to `zabaputil_cl_util_context`.
-3. **When a popup needs a utility method that is not in the copy yet,** copy it — together with every private helper it calls — from the current abap-util master state. Do not write a new implementation here and do not add a dependency on another project's copy.
-4. **Popup-specific logic does not belong in the context class.** Keep it in the popup class; only generic, reusable utilities live in the vendored copy (and therefore in abap-util).
+1. **Method-level trimming:** the copy carries only the methods the popup apps use, including the private helpers those methods need. (Method-level trimming applies to the context class only — any other class vendored from abap-util is copied as-is.)
+2. **New methods are added locally.** When a popup needs a utility method the copy doesn't have yet, write it directly into `z2ui5_cl_popup_context`. If the method already exists in abap-util, copy it from there (with its private helpers) instead of re-implementing it. Do not add a dependency on another project's copy.
+3. **Periodic AI sync-back:** every few weeks an AI compares abap-util with all consumers and merges methods that were added locally back into abap-util, so the master catalog stays the superset of all methods and other projects can reuse them.
+4. **Popup-specific logic does not belong in the context class.** Keep it in the popup class; only generic, reusable utilities live in the vendored copy (they will be harvested into abap-util by the sync).
 
 ## Coding Style
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Ready-to-use popup and dialog apps for abap2UI5. The classes in `src/` were move
 
 #### Utility Class — Vendored Copy from abap-util
 
-`z2ui5_cl_popup_context` (`src/00/`) is a **renamed copy** of `zabaputil_cl_util_context` from the [abap-util](https://github.com/abap-util/abap-util) master repository, **reduced to the methods actually used by the popup apps**. This keeps the installation dependency-free (abapGit has no dependency management) and namespace-isolated, while the utility logic itself is developed and unit-tested in exactly one place — abap-util.
+`z2ui5_cl_popup_context` (`src/00/`) is a **renamed copy** of `zabaputil_cl_util_context` from the [abap-util](https://github.com/abap-util/abap-util) master catalog, **reduced to the methods actually used by the popup apps**. This keeps the installation dependency-free (abapGit has no dependency management) and namespace-isolated, while abap-util remains the catalog that contains all utility classes with all methods.
 
-Rules:
-* Bug fixes in utility logic go to [abap-util](https://github.com/abap-util/abap-util) first, then the fix is applied identically here. Never patch only the copy.
-* The copy may differ from the master only in its class name and its method subset — implementations stay identical.
-* If a popup needs a utility method that is not in the copy yet, copy it (with its private helpers) from the current abap-util master state.
+How the copy is maintained:
+* Only the context class is trimmed at method level — unused methods are removed (the private helpers a kept method needs stay in the copy); other classes from abap-util would be vendored as-is.
+* If a popup needs a utility method that is not in the copy yet, it is added directly to the local `z2ui5_cl_popup_context` (if it already exists in abap-util, it is copied from there with its private helpers instead of re-implemented).
+* Every few weeks an AI compares abap-util with all consumers and merges locally added methods back into abap-util, so the master catalog stays the superset of all methods.
 
 #### Compatibility
 * S/4 Private Cloud or On-Premise (Standard ABAP)


### PR DESCRIPTION
## Summary
Updated documentation in AGENTS.md and README.md to clarify the maintenance model for the vendored `z2ui5_cl_popup_context` utility class copied from abap-util. The changes reflect a shift from a strict "never patch locally" approach to a more practical model that allows local additions with periodic AI-driven sync-back to the master catalog.

## Key Changes

- **Terminology update:** Changed "master repository" to "master catalog" to better describe abap-util's role as a centralized collection of utility classes
- **Maintenance model clarification:** Replaced rigid "hard constraints" with a more flexible "How the copy is maintained" section that:
  - Explicitly allows local method additions to `z2ui5_cl_popup_context`
  - Describes method-level trimming as specific to the context class only
  - Introduces the periodic AI sync-back process that harvests locally added methods back into abap-util
- **Practical guidance:** Clarified that when a popup needs a new utility method, it can be written directly in the local copy (or copied from abap-util if it already exists there)
- **Consistency:** Applied the same documentation updates to both AGENTS.md and README.md

## Notable Details

The new model acknowledges that:
1. Local additions to the vendored copy are expected and acceptable
2. An automated process periodically merges these additions back to abap-util
3. This allows abap-util to remain the superset of all utility methods across all consumers
4. The approach balances local development velocity with long-term code consolidation

https://claude.ai/code/session_01DvUbUanWkUcwmd1xCrqvcs