### PR TITLE
Add growing table support to popup table component

### DIFF
--- a/src/z2ui5_cl_popup_table.clas.abap
+++ b/src/z2ui5_cl_popup_table.clas.abap
@@ -5,10 +5,12 @@ CLASS z2ui5_cl_popup_table DEFINITION PUBLIC.
 
     CLASS-METHODS factory
       IMPORTING
-        i_tab           TYPE STANDARD TABLE
-        i_title         TYPE clike OPTIONAL
+        i_tab              TYPE STANDARD TABLE
+        i_title            TYPE clike OPTIONAL
+        i_growing          TYPE abap_bool DEFAULT abap_false
+        i_growingthreshold TYPE clike DEFAULT '20'
       RETURNING
-        VALUE(r_result) TYPE REF TO z2ui5_cl_popup_table.
+        VALUE(r_result)    TYPE REF TO z2ui5_cl_popup_table.
 
     TYPES:
       BEGIN OF ty_s_result,
@@ -27,6 +29,8 @@ CLASS z2ui5_cl_popup_table DEFINITION PUBLIC.
   PROTECTED SECTION.
     DATA title  TYPE string VALUE `Table View`.
     DATA client TYPE REF TO z2ui5_if_client.
+    DATA growing TYPE abap_bool.
+    DATA growingthreshold TYPE string.
 
     METHODS on_event.
     METHODS display.
@@ -49,7 +53,9 @@ CLASS z2ui5_cl_popup_table IMPLEMENTATION.
                                                                title      = title
           )->content( ).
 
-    DATA(tab) = popup->table( client->_bind( <tab_out> ) ).
+    DATA(tab) = popup->table( items            = client->_bind( <tab_out> )
+                              growing          = growing
+                              growingthreshold = growingthreshold ).
 
     DATA(lt_comp) = z2ui5_cl_popup_context=>rtti_get_t_attri_by_any( <tab_out> ).
 
@@ -96,6 +102,9 @@ CLASS z2ui5_cl_popup_table IMPLEMENTATION.
     ENDIF.
     r_result->mr_tab = z2ui5_cl_popup_context=>conv_copy_ref_data( i_tab ).
     CREATE DATA r_result->ms_result-row LIKE LINE OF i_tab.
+
+    r_result->growing          = i_growing.
+    r_result->growingthreshold = i_growingthreshold.
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_popup_table.clas.testclasses.abap
+++ b/src/z2ui5_cl_popup_table.clas.testclasses.abap
@@ -121,6 +121,8 @@ CLASS ltcl_test_roundtrip DEFINITION FINAL
         iv_event TYPE string.
 
     METHODS test_init_displays_table FOR TESTING RAISING cx_static_check.
+    METHODS test_growing             FOR TESTING RAISING cx_static_check.
+    METHODS test_growing_default_off FOR TESTING RAISING cx_static_check.
     METHODS test_confirm             FOR TESTING RAISING cx_static_check.
     METHODS test_cancel              FOR TESTING RAISING cx_static_check.
 
@@ -160,6 +162,35 @@ CLASS ltcl_test_roundtrip IMPLEMENTATION.
     cl_abap_unit_assert=>assert_true( xsdbool( lv_xml CS `Pick a row` ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_xml CS `{NAME}` ) ).
     cl_abap_unit_assert=>assert_true( xsdbool( lv_xml CS `{COUNT}` ) ).
+
+  ENDMETHOD.
+
+  METHOD test_growing.
+
+    DATA(lt_tab) = VALUE ty_t_tab( ( name = `row1` count = 1 ) ).
+    DATA(lo_pop) = z2ui5_cl_popup_table=>factory( i_tab              = lt_tab
+                                                  i_growing          = abap_true
+                                                  i_growingthreshold = `5` ).
+    client_create( lo_pop ).
+
+    lo_pop->z2ui5_if_app~main( mi_client ).
+
+    DATA(lv_xml) = mo_action->ms_next-s_set-s_popup-xml.
+    cl_abap_unit_assert=>assert_true( xsdbool( lv_xml CS `growing="true"` ) ).
+    cl_abap_unit_assert=>assert_true( xsdbool( lv_xml CS `growingThreshold="5"` ) ).
+
+  ENDMETHOD.
+
+  METHOD test_growing_default_off.
+
+    DATA(lt_tab) = VALUE ty_t_tab( ( name = `row1` count = 1 ) ).
+    DATA(lo_pop) = z2ui5_cl_popup_table=>factory( lt_tab ).
+    client_create( lo_pop ).
+
+    lo_pop->z2ui5_if_app~main( mi_client ).
+
+    DATA(lv_xml) = mo_action->ms_next-s_set-s_popup-xml.
+    cl_abap_unit_assert=>assert_false( xsdbool( lv_xml CS `growing="true"` ) ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
This PR adds support for the SAP UI5 "growing" feature to the popup table component, allowing tables to load data progressively as users scroll rather than loading all rows at once.

## Key Changes
- Added `i_growing` and `i_growingthreshold` parameters to the `factory()` method with sensible defaults (`abap_false` and `'20'` respectively)
- Added instance variables `growing` and `growingthreshold` to store the configuration
- Updated the `display()` method to pass these parameters to the underlying table control
- Added two new unit tests:
  - `test_growing`: Verifies that growing feature is properly enabled and threshold is set in the generated XML
  - `test_growing_default_off`: Confirms that growing is disabled by default when not explicitly configured

## Implementation Details
- The growing feature is opt-in with a default threshold of 20 rows
- Parameters are passed through to the UI5 table control's `growing` and `growingThreshold` attributes
- Backward compatible - existing code will continue to work without any changes as the feature defaults to off

https://claude.ai/code/session_01D5R5SgPLEjPdTv75uvRYBf